### PR TITLE
Add FastAPI backend scaffold with dummy Kijiji listings

### DIFF
--- a/backend/app/listings/kijiji.py
+++ b/backend/app/listings/kijiji.py
@@ -1,9 +1,13 @@
-"""Scraper for Kijiji car listings."""
+"""Dummy scraper for Kijiji car listings."""
 
 
-from .base import ListingSource
+def scrape_kijiji() -> list:
+    """Return hard-coded listings from Kijiji for testing."""
+    return [
+        {"title": "2011 Honda Civic", "price": "$4,500", "location": "Hamilton"},
+        {"title": "2010 Toyota Matrix", "price": "$5,200", "location": "Kitchener"},
+    ]
 
 
-class KijijiScraper(ListingSource):
-    """Placeholder scraper for Kijiji."""
-    pass
+__all__ = ["scrape_kijiji"]
+

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,10 +1,25 @@
-"""Entry point for the Zoomzo backend application."""
+"""FastAPI application entry point for Zoomzo backend."""
+
+from fastapi import FastAPI
+
+from app.listings.kijiji import scrape_kijiji
 
 
-def run():
-    """Placeholder function to start the backend service."""
-    pass
+app = FastAPI()
 
 
-if __name__ == "__main__":
-    run()
+@app.get("/")
+def read_root() -> dict:
+    """Simple health check endpoint."""
+    return {"Zoomzo": "Backend is running!"}
+
+
+@app.get("/listings/kijiji")
+def get_kijiji_listings() -> dict:
+    """Return dummy listings from Kijiji."""
+    listings = scrape_kijiji()
+    return {"source": "kijiji", "results": listings}
+
+
+__all__ = ["app", "read_root", "get_kijiji_listings"]
+

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,4 +1,5 @@
 # Placeholder for backend dependencies
 fastapi
+uvicorn
 pytest
 

--- a/backend/run.py
+++ b/backend/run.py
@@ -1,8 +1,7 @@
 """Run the Zoomzo backend application."""
 
-
-from app.main import run
+import uvicorn
 
 
 if __name__ == "__main__":
-    run()
+    uvicorn.run("app.main:app", host="127.0.0.1", port=8000, reload=True)


### PR DESCRIPTION
## Summary
- add FastAPI app with health check and Kijiji listing endpoints
- provide dummy Kijiji scraper returning sample data
- include uvicorn dependency and update run script

## Testing
- `pip install -r backend/requirements.txt`
- `uvicorn app.main:app --reload`
- `curl http://127.0.0.1:8000/`
- `curl http://127.0.0.1:8000/listings/kijiji`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6892e2a14e208331930198153756d39e