### PR TITLE
Simplify Kijiji listings endpoint

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -3,11 +3,26 @@
 This directory contains the Python backend responsible for scraping car listings,
 applying filters, and sending notifications.
 
-## Testing
+## Setup
 
-Install the requirements and run the test suite with `pytest`:
+Install the dependencies:
 
 ```bash
 pip install -r requirements.txt
+```
+
+## Running the server
+
+Start a development server with:
+
+```bash
+uvicorn app.main:app --reload
+```
+
+## Testing
+
+Run the test suite with `pytest`:
+
+```bash
 pytest
 ```

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -15,10 +15,9 @@ def read_root() -> dict:
 
 
 @app.get("/listings/kijiji")
-def get_kijiji_listings() -> dict:
+def get_kijiji_listings() -> list:
     """Return dummy listings from Kijiji."""
-    listings = scrape_kijiji()
-    return {"source": "kijiji", "results": listings}
+    return scrape_kijiji()
 
 
 __all__ = ["app", "read_root", "get_kijiji_listings"]


### PR DESCRIPTION
## Summary
- Return raw Kijiji listing data from `/listings/kijiji`
- Document backend setup and run instructions

## Testing
- `pip install -r backend/requirements.txt`
- `pytest`
- `cd backend && uvicorn app.main:app --reload` (verified via `curl -s http://127.0.0.1:8000/listings/kijiji`)


------
https://chatgpt.com/codex/tasks/task_e_6894137914bc8331b91427e012d94bc3